### PR TITLE
feat(fresh): check and install basic dev tools using Winget

### DIFF
--- a/bin/devx
+++ b/bin/devx
@@ -19,7 +19,7 @@ if (file_exists($local)) {
 
 
 
-$app = new Application('devx', '0.1.3');
+$app = new Application('devx', '0.1.4');
 
 $app->addCommands([
     new \App\Commands\DoctorCommand,

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "bin/devx"
   ],
   "require": {
-    "php": "^8.1",
+    "php": "^8.3",
     "symfony/console": "^6.0 | ^7.0",
     "symfony/filesystem": "^6.0",
     "symfony/process": "^6.0 |^7.2",

--- a/src/Commands/DoctorCommand.php
+++ b/src/Commands/DoctorCommand.php
@@ -110,10 +110,6 @@ class DoctorCommand extends Command
 
         if ($framework && $io->confirm("Do you want suggestions for useful $framework packages?", true)) {
             $suggestions = PackageAdvisor::getSuggestions($framework, $require, $requireDev);
-            echo '<pre>';
-            print_r($suggestions);
-            exit();
-
             if (empty($suggestions)) {
                 $io->success("No missing popular packages detected for $framework.");
             } else {

--- a/src/Enums/WingetPackage.php
+++ b/src/Enums/WingetPackage.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Enums;
+
+enum WingetPackage: string
+{
+    case Git = 'Git.Git';
+    case NodeJS = 'OpenJS.NodeJS.LTS';
+    case VSCode = 'Microsoft.VisualStudioCode';
+    case WindowsTerminal = 'Microsoft.WindowsTerminal';
+    case Zip7 = '7zip.7zip';
+    case Postman = 'Postman.Postman';
+    case OhMyPosh = 'JanDeDobbeleer.OhMyPosh';
+    case FiraCode = 'NerdFonts.FiraCode';
+    case Python = 'Python.Python.3';
+    case GitHubCLI = 'GitHub.cli';
+    case Docker = 'Docker.DockerDesktop';
+    case Insomnia = 'Kong.Insomnia';
+    case Neovim = 'Neovim.Neovim';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Git => 'Git',
+            self::NodeJS => 'Node.js LTS',
+            self::VSCode => 'Visual Studio Code',
+            self::WindowsTerminal => 'Windows Terminal',
+            self::Zip7 => '7-Zip',
+            self::Postman => 'Postman',
+            self::OhMyPosh => 'Oh My Posh',
+            self::FiraCode => 'Fira Code (Nerd Font)',
+            self::Python => 'Python 3',
+            self::GitHubCLI => 'GitHub CLI',
+            self::Docker => 'Docker Desktop',
+            self::Insomnia => 'Insomnia',
+            self::Neovim => 'Neovim',
+        };
+    }
+
+    public function description(): string
+    {
+        return match ($this) {
+            self::Git => 'Contrôle de version distribué',
+            self::NodeJS => 'Runtime JavaScript + npm/yarn',
+            self::VSCode => 'Éditeur de code moderne',
+            self::WindowsTerminal => 'Terminal multi-shell moderne',
+            self::Zip7 => 'Outil de compression/décompression',
+            self::Postman => 'Testeur d’API REST',
+            self::OhMyPosh => 'Custom prompt pour PowerShell/Terminal',
+            self::FiraCode => 'Police avec ligatures & icônes pour devs',
+            self::Python => 'Langage de script et d’automatisation',
+            self::GitHubCLI => 'Interface GitHub en ligne de commande',
+            self::Docker => 'Conteneurisation pour dev local',
+            self::Insomnia => 'Alternative à Postman, légère et rapide',
+            self::Neovim => 'Éditeur terminal ultra rapide pour puristes',
+        };
+    }
+
+    public static function get(string $packageName): ?WingetPackage
+    {
+        return self::tryFromName($packageName);
+    }
+
+    private static function tryFromName(string $name): ?WingetPackage
+    {
+        foreach (self::cases() as $case) {
+            print_r($case);
+            if ($case->name === $name) {
+                return $case;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/PackageManager/Manager.php
+++ b/src/PackageManager/Manager.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\PackageManager;
+
+class Manager
+{
+    public static function resolve(): string
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            if (ChocolateyManager::isAvailable()) {
+                return ChocolateyManager::class;
+            }
+
+            if (WingetManager::isAvailable()) {
+                return WingetManager::class;
+            }
+        }
+
+        if (PHP_OS_FAMILY === 'Darwin') {
+            // MacOs
+        }
+
+        if (PHP_OS_FAMILY === 'Linux') {
+
+        }
+
+        // MacOS / Linux à venir
+        throw new \RuntimeException('No supported package manager found.');
+    }
+}

--- a/src/PackageManager/PackageManagerInterface.php
+++ b/src/PackageManager/PackageManagerInterface.php
@@ -19,10 +19,12 @@ interface PackageManagerInterface
     /**
      * Install a package using the package manager.
      */
-    public static function install(string $package): bool;
+    public static function install(string $package): void;
 
     /**
      * Ensure a package is installed; may provide console feedback.
      */
     public static function ensureInstalled(string $package, SymfonyStyle $io): void;
+
+    public function installByToolName(string $toolName): bool;
 }

--- a/src/PackageManager/WingetManager.php
+++ b/src/PackageManager/WingetManager.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\PackageManager;
+
+use App\Enums\WingetPackage;
+use App\Utils\Shell;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Process;
+
+class WingetManager implements PackageManagerInterface
+{
+    public static function isAvailable(): bool
+    {
+        return Shell::runVersionCommand('winget -v') !== null;
+    }
+
+    public static function isPackageInstalled(string $packageName): bool
+    {
+        $package = WingetPackage::get($packageName)->value;
+        $process = Process::fromShellCommandline("winget list --id {$package} --source winget");
+        $process->run();
+
+        return $process->isSuccessful() && str_contains($process->getOutput(), $package);
+    }
+
+    public static function install(string $package): void
+    {
+        $wingetPackage = WingetPackage::get($package);
+        if (! $wingetPackage) {
+
+        }
+        if (self::isPackageInstalled($package)) {
+            exit("package $package is already installed");
+        } else {
+            exit('package '.$package.' is not installed');
+        }
+        Shell::runInstallCommand("winget install --id {$wingetPackage->value} -e");
+    }
+
+    public static function ensureInstalled(string $package, SymfonyStyle $io): void
+    {
+        if ((! self::isAvailable())) {
+            $io->error('winget is not installed on this system');
+        }
+    }
+
+    public function installByToolName(string $toolName): bool
+    {
+
+        $package = WingetPackage::get($toolName);
+
+        if (! $package) {
+            return false;
+        }
+
+        $this->install($package->value);
+    }
+}

--- a/src/Utils/Shell.php
+++ b/src/Utils/Shell.php
@@ -28,10 +28,34 @@ class Shell
         return null;
     }
 
-    public static function runCommand(string $command): void
+    public static function runCommand(string $command): string
     {
         $process = Process::fromShellCommandline($command);
-        $process->run();
-        exit($process);
+        $process->run(function ($_, $buffer) {
+            echo $buffer;
+        });
+
+        return $process->getOutput();
+    }
+
+    public static function runInstallCommand(string $command): string
+    {
+        $process = Process::fromShellCommandline($command);
+        $process->run(function ($type, $buffer) {
+            echo $buffer;
+        });
+
+        if (! $process->isSuccessful()) {
+            $exitCode = $process->getExitCode();
+            $error = $process->getErrorOutput();
+
+            if (! $process->getStopSignal()) {
+                throw new \RuntimeException('❌ Installation annulée : élévation refusée par l’utilisateur.');
+            }
+
+            throw new \RuntimeException("❌ Erreur durant l'installation : {$error}");
+        }
+
+        return $process->getOutput();
     }
 }


### PR DESCRIPTION
- Adds detection of essential tools (node, npm, nvm, etc.) in the `fresh` command
- Integrates installation flow using the default package manager (Winget)
- Improves CLI output with clear "found" and "missing" sections
- Removes obsolete Chocolatey and Winget implementations
- Updates `PackageManagerInterface` to support `installByToolName`